### PR TITLE
Replace chat <input> with <textarea> to allow line breaks

### DIFF
--- a/appdrawdance/drawdance_web/src/Common.ts
+++ b/appdrawdance/drawdance_web/src/Common.ts
@@ -55,8 +55,8 @@ export function isBlank(value: string | undefined | null): boolean {
 
 export function changeInput(
   setter: (newValue: string) => void
-): React.ChangeEventHandler<HTMLInputElement> {
-  return (event: React.ChangeEvent<HTMLInputElement>) => {
+): React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> {
+  return (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setter(event.target.value);
   };
 }

--- a/appdrawdance/drawdance_web/src/index.css
+++ b/appdrawdance/drawdance_web/src/index.css
@@ -118,3 +118,11 @@ body {
 .overflow-y-scroll {
   overflow-y: scroll;
 }
+
+#chat-input {
+  resize: none;
+}
+
+.chat-message {
+  white-space: pre-line;
+}

--- a/scripts/cmake-presets
+++ b/scripts/cmake-presets
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2022 askmeaboutloom
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
- Fixed `scripts/cmake-presets` shebang pointing to `sh` instead of `bash`
- Fixed auto-scroll not working by using a `useLayoutEffect` instead of a `useEffect`. (`useLayoutEffect` runs after a DOM update).
- Made it not scroll if the user has manually scrolled up to read earlier messages, auto-scroll is restored when the user scrolls back to the bottom manually.
- Made the chat input a textarea to allow for lines breaks (using `Shift + Enter`, like discord). Made the textarea auto-resize when a new line is typed. Since the textarea eats `Enter` keys, the form with the `onSubmit` event isn't being triggered, so I manually call `submit()` when `Enter` without `Shift` is pressed.

Thanks.